### PR TITLE
Install WP-CLI tab completions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,8 @@ RUN set -ex; \
     # Install WP-CLI
     curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar; \
     chmod +x wp-cli.phar; \
-    mv wp-cli.phar /usr/local/bin/wp
+    mv wp-cli.phar /usr/local/bin/wp; \
+    # Install WP-CLI tab completions
+    curl -O https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash; \
+    mv wp-completion.bash /etc/wp-completion.bash; \
+    echo 'source /etc/wp-completion.bash' >> /etc/bash.bashrc; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ RUN set -ex; \
     curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar; \
     chmod +x wp-cli.phar; \
     mv wp-cli.phar /usr/local/bin/wp; \
+    \
     # Install WP-CLI tab completions
     curl -O https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash; \
     mv wp-completion.bash /etc/wp-completion.bash; \
-    echo 'source /etc/wp-completion.bash' >> /etc/bash.bashrc; \
+    echo 'source /etc/wp-completion.bash' >> /etc/bash.bashrc


### PR DESCRIPTION
Enables WP-CLI tab completions for all users, although notably they won't work with the root user because of the warning message WP-CLI outputs.